### PR TITLE
nf-quilt support for NextFlow 23.04

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1408,6 +1408,13 @@
         "date": "2023-03-08T10:56:53.523525-08:00",
         "sha512sum": "2a4c9952090851d63010500d3777d50545f6d2521e928fc06799e2cf57fb24dbdf666e89652f74d0aad99d0ed188f62ae9573b8c014c7206da6ce4e0190c1be5",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.3.4",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.3.4/nf-quilt-0.3.4.zip",
+        "date": "2023-04-04T22:44:41.864152-07:00",
+        "sha512sum": "a8d645201f72cb4758494e5cb357c6c7db31c24fb907479d04c124f44cf0665e8305603ea7b0416e20f318f29c39f98c8f7d8be3f0d9d1f892c6db8216f23ae0",
+        "requires": ">22.10.6"
       }
     ]
   },


### PR DESCRIPTION
Turns out I did not properly update my manifest.
This also adds support for customizing the Quilt Package
and preliminary Benchling integration