### PR TITLE
Feat: Add experimental support for Jarvice plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1467,5 +1467,17 @@
         "requires": ">23.02.01-edge"
       }
     ]
+  },
+  {
+    "id": "nf-jarvice",
+    "releases": [
+      {
+        "version": "0.5.0",
+        "url": "https://github.com/nimbix/nf-jarvice/releases/download/0.5.0/nf-jarvice-0.5.0.zip",
+        "date": "2023-04-04T00:00:14.872+01:00",
+        "sha512sum": "cc062e8b1d4ef0444ef143222f930bfb12508ab9f4dd9fc09a79730c133db93cc06fb5d8bf845fc047dc9910de15df6d77447280b7505c03c792930811c3c743",
+        "requires": ">=23.02.0-edge"
+      }
+    ]
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -1472,11 +1472,11 @@
     "id": "nf-jarvice",
     "releases": [
       {
-        "version": "0.5.0",
-        "url": "https://github.com/nimbix/nf-jarvice/releases/download/0.5.0/nf-jarvice-0.5.0.zip",
-        "date": "2023-04-04T00:00:14.872+01:00",
-        "sha512sum": "cc062e8b1d4ef0444ef143222f930bfb12508ab9f4dd9fc09a79730c133db93cc06fb5d8bf845fc047dc9910de15df6d77447280b7505c03c792930811c3c743",
-        "requires": ">=23.02.0-edge"
+        "version": "0.6.0",
+        "date": "2023-04-19T12:48:08.340787+04:00",
+        "url": "https://github.com/nimbix/nf-jarvice/releases/download/0.6.0/nf-jarvice-0.6.0.zip",
+        "requires": ">=23.02.0-edge",
+        "sha512sum": "306d2ddd6a56d4c501f49d787648508ce2c876fe319541b22580fe0ee0e178709f6996b059a7c52100f41008a4aa97b0fe5e4fedb6ed96863bc25eb382bf1f7c"
       }
     ]
   }


### PR DESCRIPTION
Dear Nextflow team,

I am trying to do a full validation before submitting the plugin to you, so this PR is a Draft for now.
To do so, I tried to hardcode a different plugins.json url into nextflow to use a forked version of yours and so be able to emulate what would happen.
But I fail to do so 😕

Changes I made are the following:

```
diff --git a/modules/nf-commons/src/main/nextflow/plugin/Plugins.groovy b/modules/nf-commons/src/main/nextflow/plugin/Plugins.groovy
index 0ed48a86a..6e81b2f70 100644
--- a/modules/nf-commons/src/main/nextflow/plugin/Plugins.groovy
+++ b/modules/nf-commons/src/main/nextflow/plugin/Plugins.groovy
@@ -31,7 +31,7 @@ import org.pf4j.PluginManager
 @CompileStatic
 class Plugins {

-    public static final String DEFAULT_PLUGINS_REPO = 'https://raw.githubusercontent.com/nextflow-io/plugins/main/plugins.json'
+    public static final String DEFAULT_PLUGINS_REPO = 'https://raw.githubusercontent.com/oxedions/plugins/main/plugins.json'

     private final static PluginsFacade INSTANCE = new PluginsFacade()

diff --git a/plugins/build.gradle b/plugins/build.gradle
index 78b2656ff..7425ed166 100644
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -194,7 +194,7 @@ project.parent.tasks.getByName("assemble").dependsOn << assemble
  * Merge and publish the plugins index file
  */
 task publishIndex( type: GithubRepositoryPublisher ) {
-    indexUrl = 'https://github.com/nextflow-io/plugins/main/plugins.json'
+    indexUrl = 'https://github.com/oxedions/plugins/main/plugins.json'
     repos = allPlugins()
     owner = github_organization
     githubUser = github_username
```

Then I did a `make clean && make compile && make assemble` so I was assuming that nextflow would now use my own url, but it seems not:
```

Apr-11 13:04:33.590 [main] DEBUG nextflow.cli.CmdRun - Applied DSL=2 from script declararion
Apr-11 13:04:33.608 [main] INFO  nextflow.cli.CmdRun - Launching `test.nf` [evil_varahamihira] DSL2 - revision: ce903c8f68
Apr-11 13:04:33.608 [main] DEBUG nextflow.plugin.PluginsFacade - Plugins declared=[nf-jarvice@0.5.0]
Apr-11 13:04:33.609 [main] DEBUG nextflow.plugin.PluginsFacade - Plugins default=[]
Apr-11 13:04:33.609 [main] DEBUG nextflow.plugin.PluginsFacade - Plugins resolved requirement=[nf-jarvice@0.5.0]
Apr-11 13:04:33.609 [main] DEBUG nextflow.plugin.PluginUpdater - Installing plugin nf-jarvice version: 0.5.0
Apr-11 13:04:33.612 [main] INFO  nextflow.plugin.PluginUpdater - Downloading plugin nf-jarvice@0.5.0
Apr-11 13:04:33.953 [main] INFO  org.pf4j.update.UpdateManager - Plugin with id nf-jarvice does not exist in any repository
```

Is there a way to force nextflow to use a different URL to pickup plugins list ?


