### PR TITLE
Update nf-cws to  v1.0.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1619,6 +1619,13 @@
         "date": "2023-03-20T16:06:43.520357+01:00",
         "sha512sum": "2183c625a4c0699d834972a26f9d17ae30eb5348c381cb7b297ce0bc2d0395d084f47bf08d20dc1dbab010f4bca1c7f05a2e9642d2b6a150769fd760ba77e94e",
         "requires": ">23.02.01-edge"
+      },
+      {
+        "version": "1.0.1",
+        "date": "2023-06-09T14:38:46.678551+02:00",
+        "url": "https://github.com/CommonWorkflowScheduler/nf-cws/releases/download/1.0.1/nf-cws-1.0.1.zip",
+        "requires": ">23.02.01-edge",
+        "sha512sum": "7d1043376f099ac07a2f34151c7b519ae5233724d6eb26b2f6529c9351c070f3470a47f011731b74d3e3837d68ee86010c53cb63f2047ae8b0a8b2bdd0555e1c"
       }
     ]
   },


### PR DESCRIPTION
- automatically use the latest version of the Kubernetes Scheduler Docker Image [[commit](https://github.com/CommonWorkflowScheduler/nf-cws/commit/da42dfcafed7f7c97490b14a99999922545ed1f3)]
- allow to submit additionally arguments to the Common Workflow Scheduler Interface [[commit](https://github.com/CommonWorkflowScheduler/nf-cws/commit/5e38d980fcbd088d606c7a07f5bdfa46b98e7eb1)]