### PR TITLE
Add nf-float release 0.1.8

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1746,6 +1746,13 @@
         "date": "2023-05-25T17:24:17.211959+08:00",
         "sha512sum": "86d69ae625f920c80e92b12311671ee88683219040ad09f9d9057f6b324cc901e35e470604f8c901daaba570f1a412a3161e7945e8ba53a3967fa940d90d3251",
         "requires": ">=22.10.0"
+      },
+      {
+        "version": "0.1.8",
+        "date": "2023-07-13T17:30:00.621671+08:00",
+        "url": "https://github.com/MemVerge/nf-float/releases/download/0.1.8/nf-float-0.1.8.zip",
+        "requires": ">=22.10.0",
+        "sha512sum": "d4f024d6d0610b87aaf302444c55dd90cf93837d20ccc6cc576b3e3afc5bec5a25bf4d0bafe051f1a05471bc3975a6a534b1dc243097921aff0e0cd90b54a291"
       }
     ]
   }


### PR DESCRIPTION
Release 0.1.8 includes multiple bugfixes:

* [GH-20] Update project's org. name. by @jealous in https://github.com/MemVerge/nf-float/pull/21
* [GH-22] Include auto-install in the document by @jealous in https://github.com/MemVerge/nf-float/pull/23
* [GH-26] Support config in process. by @jealous in https://github.com/MemVerge/nf-float/pull/33
* [GH-32] Upload bin directory. by @jealous in https://github.com/MemVerge/nf-float/pull/34
* [GH-28] Correct syntax in README. by @jealous in https://github.com/MemVerge/nf-float/pull/36
* [GH-29] Read credentials from ENV or secrets. by @jealous in https://github.com/MemVerge/nf-float/pull/35
* [GH-38] Track job with tags by @jealous in https://github.com/MemVerge/nf-float/pull/39
* [GH-37] Support default registry. by @jealous in https://github.com/MemVerge/nf-float/pull/40

**Full Changelog**: https://github.com/MemVerge/nf-float/compare/0.1.7...0.1.8