### PR TITLE
nf-quilt 0.4.3: only publish on success, customize README

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1576,6 +1576,13 @@
         "date": "2023-04-05T11:32:51.334559-07:00",
         "sha512sum": "09fe7c2b2941e1942a244ee2bc6faa3389b4190dc222a5d046244c2ba1fe74bf316bfa73ff113d3f975297add2b370440bd860bba41f8b40f4d27619937967fa",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.4.0",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.4.0/nf-quilt-0.4.0.zip",
+        "date": "2023-05-19T18:00:22.425192-07:00",
+        "sha512sum": "775a2164541f0b87f4aa2eca6f1e0af9482777801801fb33527f59e28f469af89c69c1660e23569c85f2134b3158d312a0a0ab0118d8f53f9a8d154527a41529",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -1590,6 +1590,13 @@
         "date": "2023-06-02T15:45:52.551323-07:00",
         "sha512sum": "a0174b5055c1c139959c36b533c740a30d9e663e03a790378b3bc53e60ef498bdae3626291c117eb73edfc75093da275f78f402582c6c6b88d4b7a2a8e59fd37",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.4.2",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.4.2/nf-quilt-0.4.2.zip",
+        "date": "2023-07-02T21:42:45.641808-07:00",
+        "sha512sum": "bd426428eaf6a5a5942958cc1795943e1e62d62c9f90e15a877fee2fc5a391831f312fb876c00153957a770ea3a4d04777ef37665d69d1933a2b00c7e2d1a62a",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -1583,6 +1583,13 @@
         "date": "2023-05-19T18:00:22.425192-07:00",
         "sha512sum": "775a2164541f0b87f4aa2eca6f1e0af9482777801801fb33527f59e28f469af89c69c1660e23569c85f2134b3158d312a0a0ab0118d8f53f9a8d154527a41529",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.4.1",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.4.1/nf-quilt-0.4.1.zip",
+        "date": "2023-06-02T15:45:52.551323-07:00",
+        "sha512sum": "a0174b5055c1c139959c36b533c740a30d9e663e03a790378b3bc53e60ef498bdae3626291c117eb73edfc75093da275f78f402582c6c6b88d4b7a2a8e59fd37",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -1597,6 +1597,13 @@
         "date": "2023-07-02T21:42:45.641808-07:00",
         "sha512sum": "bd426428eaf6a5a5942958cc1795943e1e62d62c9f90e15a877fee2fc5a391831f312fb876c00153957a770ea3a4d04777ef37665d69d1933a2b00c7e2d1a62a",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.4.3",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.4.3/nf-quilt-0.4.3.zip",
+        "date": "2023-07-27T17:42:44.618233-07:00",
+        "sha512sum": "ed1d7895fc6fb4a73e9fc7fe0eb7a02ae96b57cadddfd3547b52a34834da40afc89b4451e7fc9551999931b83e87c8e4ebf592bf936a4d492b9f09d96b2ea0fc",
+        "requires": ">=22.10.6"
       }
     ]
   },


### PR DESCRIPTION
Note that the last couple versions were not formally published, as they were used for private testing