### PR TITLE
nf-quilt 0.4.5

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1779,6 +1779,13 @@
         "date": "2023-08-22T19:44:48.017046-07:00",
         "sha512sum": "69a47e82d22ad254cef359d3d7ac6ca0354ea2c2536bde7114be3ca2a57cf39f9cfefe6badd5b57af4dfce345bd2ccee4160000ab923509b843c08d454ea7539",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.4.5",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.4.5/nf-quilt-0.4.5.zip",
+        "date": "2023-08-25T10:26:10.17939-07:00",
+        "sha512sum": "fc50088e5ba72dce117f7a9bce9bb31811aa66ef9c2ea5e303312d6b085daa8955470830da7faa77a432d0c406712d432b00286502e5090753397eb186551584",
+        "requires": ">=22.10.6"
       }
     ]
   },
@@ -1924,10 +1931,10 @@
       },
       {
         "version": "0.3.1",
-        "date": "2023-08-21T16:06:48.435747+08:00",
         "url": "https://github.com/MemVerge/nf-float/releases/download/0.3.1/nf-float-0.3.1.zip",
-        "requires": ">=23.04.0",
-        "sha512sum": "7bd0e18e4d0b20a38ba79fc9b0e977fd4580c6c0302ac3e703d32945ba26a58e5c9d5f44e522ae6c11e5e234bf201cd3d7716fdabce5d0b3a72378df9cb118dd"
+        "date": "2023-08-21T16:06:48.435747+08:00",
+        "sha512sum": "7bd0e18e4d0b20a38ba79fc9b0e977fd4580c6c0302ac3e703d32945ba26a58e5c9d5f44e522ae6c11e5e234bf201cd3d7716fdabce5d0b3a72378df9cb118dd",
+        "requires": ">=23.04.0"
       }
     ]
   },


### PR DESCRIPTION
## [0.4.5] 2023-08-23

- fix metadata in README.md
- write out nf-quilt/*.json files
- add summarize wildcards (md, html) for QuiltProduct
- redo normalizedPaths
- reduce logging (especially stack traces and filesystem calls)
- convert non-fatal errors to warnings