### PR TITLE
Add the plugin nf-dotenv from @fulcrumgenomics

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2192,5 +2192,17 @@
         "requires": ">=23.07.0-edge"
       }
     ]
+  },
+  {
+    "id": "nf-dotenv",
+    "releases": [
+      {
+        "version": "1.0.0",
+        "date": "2023-11-21T21:56:18.814126-08:00",
+        "url": "https://github.com/fulcrumgenomics/nf-dotenv/releases/download/1.0.0/nf-dotenv-1.0.0.zip",
+        "requires": ">=22.10.2",
+        "sha512sum": "7cae188cdf5f1d5ba0283e7e80a70a220e3716dba3ec1b22b6fbe35a28c589044d493020d88ae1e9a2a7b4894b291b20498dd46b7dcf9e05c2f04aa8bbf6085d"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Hello Nextflow community and Seqera!

I've written a small plugin that helps in complex containerized Nextflow projects where a GitHub repository may be orchestrated (build and publish) with Docker Compose and all container version labels are stored in the [dotenv](https://hexdocs.pm/dotenvy/dotenv-file-format.html) file ([relevant Docker Compose docs](https://docs.docker.com/compose/environment-variables/set-environment-variables/)).

To reduce duplication of setting container versions in both a dotenv file and also again in Nextflow configuration (and risk them going out of sync), this plugin can be used to automatically pull those versions from the dotenv file into the Nextflow scope using an importable function.

The upstream repository is here:

- https://github.com/fulcrumgenomics/nf-dotenv

This is my first time writing a plugin and seeking inclusion into the plugin registry; please let me know if I've missed a step or need to edit the submission!

I added a mini "real world example" on why you might use this plugin in the docs:

- https://github.com/fulcrumgenomics/nf-dotenv#a-real-world-example

Thank you for your time in reviewing this request!