### PR TITLE
nf-quilt 0.7.9

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2010,6 +2010,13 @@
         "date": "2023-10-17T12:48:27.411345+02:00",
         "sha512sum": "62dc9ae3cab622d79d1fd2d34c88f99e6c7cba1f7db77d98c6b6a883c126a176f0b2297a8eea87f5b8b37b5bb0c774090c452e9a3ab8dc9cf5845accaa1bde6e",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.7.9",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.9/nf-quilt-0.7.9.zip",
+        "date": "2024-01-29T20:13:51.775102-08:00",
+        "sha512sum": "03887c9ec4f2cfeeeeb8a14282708b38c419a2e63be4b2a773787db998a6e990e0f542eda8c7617c3da713785440512c4954864619fc4290bd3c62a9fc2a61b4",
+        "requires": ">=22.10.6"
       }
     ]
   },
@@ -2343,17 +2350,17 @@
     "releases": [
       {
         "version": "0.1.0",
-        "date": "2023-12-14T23:11:20.380355-06:00",
         "url": "https://github.com/phac-nml/nf-iridanext/releases/download/0.1.0/nf-iridanext-0.1.0.zip",
-        "requires": ">=22.10.0",
-        "sha512sum": "f3756efb666dc922c396748e43c8d45e4b61d081bc6a8016a344620c581e26d5c97784a11e8664357a019df16c736b959b1db0a1061a23f7d61b5fd714bbe500"
+        "date": "2023-12-14T23:11:20.380355-06:00",
+        "sha512sum": "f3756efb666dc922c396748e43c8d45e4b61d081bc6a8016a344620c581e26d5c97784a11e8664357a019df16c736b959b1db0a1061a23f7d61b5fd714bbe500",
+        "requires": ">=22.10.0"
       },
       {
         "version": "0.2.0",
-        "date": "2024-01-22T08:37:59.686396-06:00",
         "url": "https://github.com/phac-nml/nf-iridanext/releases/download/0.2.0/nf-iridanext-0.2.0.zip",
-        "requires": ">=22.10.0",
-        "sha512sum": "70d021683b867a198d355ec19ecb07399b85d58fe0996d66092fd48ab75c14c8cfca9ef287a6c7dc4dc57124369046200ea8b20ff5e4d086268203a4db998c05"
+        "date": "2024-01-22T08:37:59.686396-06:00",
+        "sha512sum": "70d021683b867a198d355ec19ecb07399b85d58fe0996d66092fd48ab75c14c8cfca9ef287a6c7dc4dc57124369046200ea8b20ff5e4d086268203a4db998c05",
+        "requires": ">=22.10.0"
       }
     ]
   },
@@ -2362,10 +2369,10 @@
     "releases": [
       {
         "version": "1.0.0-beta",
-        "date": "2024-01-17T10:46:46+01:00",
         "url": "https://github.com/nextflow-io/nf-co2footprint/releases/download/1.0.0-beta/nf-co2footprint-1.0.0-beta.zip",
-        "requires": ">=23.07.0",
-        "sha512sum": "b63d137bb2456a5bd31dcfa83acb9241c9cc5c1c88c9f611445f101dd44ede7e9c8848e83083b391096533f0613142ed44bf876d27e6890ea77b14c6c4caf8c5"
+        "date": "2024-01-17T10:46:46+01:00",
+        "sha512sum": "b63d137bb2456a5bd31dcfa83acb9241c9cc5c1c88c9f611445f101dd44ede7e9c8848e83083b391096533f0613142ed44bf876d27e6890ea77b14c6c4caf8c5",
+        "requires": ">=23.07.0"
       }
     ]
   }


### PR DESCRIPTION
* Properly read input path URIs (auto-install)
* Support array metadata
* Better debugging and error reporting (fewer silent failures)