### PR TITLE
nf-quilt v0.7.13

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2360,6 +2360,13 @@
         "date": "2024-06-17T16:01:11.023858-07:00",
         "sha512sum": "243885dd4ebeeb8e8d99d5f2c95ed071675f889f8809b86c47f461e2f7889cea45c734e65ba2859fed25cef506e814bca9669eb0ad24814aeb92f0c5f1dc8e05",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.7.16",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.16/nf-quilt-0.7.16.zip",
+        "date": "2024-06-18T16:12:31.391847-07:00",
+        "sha512sum": "02db7790f09a544c6bf4ae8a462c4195f412827a57ba3585cb6267d8788886bb83b705e27846dc3a3996fcc38496cba19e75f134534942b8742adf03a6116ee1",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -2346,6 +2346,13 @@
         "date": "2024-06-13T16:58:19.038733-07:00",
         "sha512sum": "a12f42afddc2341f8f516f52b849d910bf5286ef64ff07ee2c56fbbdfcabad2e0cae88de620b2ab476ff491fe33667679764698e50d31d441e2d9adf86a2ccd6",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.7.14",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.14/nf-quilt-0.7.14.zip",
+        "date": "2024-06-14T13:03:00.09833-07:00",
+        "sha512sum": "564f229ebdc4aeb620d0861d307d5d2286fc08df784ee02297bef7c0135cea6b9ef0d2693a50d146f2456e53d550092d6fbc616b3f8608ad10959a62a351b204",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -2353,6 +2353,13 @@
         "date": "2024-06-14T13:03:00.09833-07:00",
         "sha512sum": "564f229ebdc4aeb620d0861d307d5d2286fc08df784ee02297bef7c0135cea6b9ef0d2693a50d146f2456e53d550092d6fbc616b3f8608ad10959a62a351b204",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.7.15",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.15/nf-quilt-0.7.15.zip",
+        "date": "2024-06-17T16:01:11.023858-07:00",
+        "sha512sum": "243885dd4ebeeb8e8d99d5f2c95ed071675f889f8809b86c47f461e2f7889cea45c734e65ba2859fed25cef506e814bca9669eb0ad24814aeb92f0c5f1dc8e05",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -2341,13 +2341,6 @@
         "requires": ">=22.10.6"
       },
       {
-        "version": "0.7.12",
-        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.12/nf-quilt-0.7.12.zip",
-        "date": "2024-05-16T10:48:05.694926-07:00",
-        "sha512sum": "644bd7eeb2daa33f610e752659340cfc16cc9aa50b00f0430fb97c62c9197caceaf93d35fc32e2fcdc1cb483ce4028b6b1d32c6a6aaa3493e54e08a2fb0b1937",
-        "requires": ">=22.10.6"
-      },
-      {
         "version": "0.7.13",
         "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.13/nf-quilt-0.7.13.zip",
         "date": "2024-06-13T16:58:19.038733-07:00",

--- a/plugins.json
+++ b/plugins.json
@@ -2346,6 +2346,13 @@
         "date": "2024-05-16T10:48:05.694926-07:00",
         "sha512sum": "644bd7eeb2daa33f610e752659340cfc16cc9aa50b00f0430fb97c62c9197caceaf93d35fc32e2fcdc1cb483ce4028b6b1d32c6a6aaa3493e54e08a2fb0b1937",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.7.13",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.13/nf-quilt-0.7.13.zip",
+        "date": "2024-06-13T16:58:19.038733-07:00",
+        "sha512sum": "a12f42afddc2341f8f516f52b849d910bf5286ef64ff07ee2c56fbbdfcabad2e0cae88de620b2ab476ff491fe33667679764698e50d31d441e2d9adf86a2ccd6",
+        "requires": ">=22.10.6"
       }
     ]
   },

--- a/plugins.json
+++ b/plugins.json
@@ -2339,6 +2339,13 @@
         "date": "2024-01-29T20:13:51.775102-08:00",
         "sha512sum": "03887c9ec4f2cfeeeeb8a14282708b38c419a2e63be4b2a773787db998a6e990e0f542eda8c7617c3da713785440512c4954864619fc4290bd3c62a9fc2a61b4",
         "requires": ">=22.10.6"
+      },
+      {
+        "version": "0.7.12",
+        "url": "https://github.com/quiltdata/nf-quilt/releases/download/0.7.12/nf-quilt-0.7.12.zip",
+        "date": "2024-05-16T10:48:05.694926-07:00",
+        "sha512sum": "644bd7eeb2daa33f610e752659340cfc16cc9aa50b00f0430fb97c62c9197caceaf93d35fc32e2fcdc1cb483ce4028b6b1d32c6a6aaa3493e54e08a2fb0b1937",
+        "requires": ">=22.10.6"
       }
     ]
   },


### PR DESCRIPTION
- catch FileNotFound (mis-interaction with latest nf-validation)
- Fix getFileName()
- Debug build of QuiltCore-Java
- Fail when pushing to read-only buckets