### PR TITLE
Fix the SHA sum for nf-nomad

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2871,7 +2871,7 @@
         "date": "2024-06-26T13:21:13.702327+02:00",
         "url": "https://github.com/nextflow-io/nf-nomad/releases/download/0.1.0/nf-nomad-0.1.0.zip",
         "requires": ">=23.10.0",
-        "sha512sum": "34a1ab68478acd5b8d816517bd8f5fd67fee858ed01da0ce24ea7b8eca6aaab5909fd6e5cccf1c5ce7ca78b01b4c33cf3402935a1a88c2c68dfa210e503f1da0"
+        "sha512sum": "9e59d60ffa925f1e63b8e79c1ecced80ea754eb06014fc3b5f8008d457368ea8568df87304beb4d3038dc09a0bc92a3517980d22014318cbd9f39f5a661d551e"
       }
     ]
   }


### PR DESCRIPTION
This PR builds upon #76 and address the issue identified by @jagedn 

 
```
Downloading plugin nf-nomad@0.1.0
ERROR ~ SHA512 checksum of downloaded file nf-nomad-0.1.0.zip does not match that from plugin descriptor. Got 9e59d60ffa925f1e63b8e79c1ecced80ea754eb06014fc3b5f8008d457368ea8568df87304beb4d3038dc09a0bc92a3517980d22014318cbd9f39f5a661d551e but expected 34a1ab68478acd5b8d816517bd8f5fd67fee858ed01da0ce24ea7b8eca6aaab5909fd6e5cccf1c5ce7ca78b01b4c33cf3402935a1a88c2c68dfa210e503f1da0
```