### PR TITLE
Add nf-float v0.4.3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2789,6 +2789,13 @@
         "date": "2024-07-23T22:04:05.536678-07:00",
         "sha512sum": "4a820c737717bf12ed8847d455c7390ff02464c2cbd928fc282ff3dae0bda575ee85e775c520607bfe1e979017fc7871b85b9d42c5e849e895611ec47478427e",
         "requires": ">=23.04.0"
+      },
+      {
+        "version": "0.4.3",
+        "date": "2024-08-15T14:24:48.081118-07:00",
+        "url": "https://github.com/MemVerge/nf-float/releases/download/0.4.3/nf-float-0.4.3.zip",
+        "requires": ">=23.04.0",
+        "sha512sum": "b190fb1d3f4c4b8d59fdf9fd0938a4185e4ba79869e0dd0001a25c35f93b6fa7c92f650ee3e670a8b43bdfe0662b979cc4c9c9ecf3439c5ac1bffd8caba91d36"
       }
     ]
   },


### PR DESCRIPTION
Upgrade nf-float plugin to 0.4.3. This version includes a fix that sometimes the job status in MMC is not updated to Nextflow properly.

The root cause is that we depend on a full job list for individual job status update.  But sometimes the full poll doesn't take place or doesn't finish in time.

The fix is to create the status entry for each job in the plugin right after we submit a job to MMC.

Regression test has been run with nf-core/rnaseq test profile on MMC.

The change is available at:
https://github.com/MemVerge/nf-float/pull/74