### PR TITLE
Add nf-float 0.4.4

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2824,6 +2824,13 @@
         "date": "2024-08-15T14:24:48.081118-07:00",
         "sha512sum": "b190fb1d3f4c4b8d59fdf9fd0938a4185e4ba79869e0dd0001a25c35f93b6fa7c92f650ee3e670a8b43bdfe0662b979cc4c9c9ecf3439c5ac1bffd8caba91d36",
         "requires": ">=23.04.0"
+      },
+      {
+        "version": "0.4.4",
+        "date": "2024-09-11T15:43:34.567847-07:00",
+        "url": "https://github.com/MemVerge/nf-float/releases/download/0.4.4/nf-float-0.4.4.zip",
+        "requires": ">=23.04.0",
+        "sha512sum": "29ab5cc167f2ac6f33e646e4caf9378bc2f3007d8c93aa4cdf549b8e05f02ec5999f0461fe866de9c3ca876cae101f5eb8a6d8c58a44ad61bd1ac7946001dc40"
       }
     ]
   },


### PR DESCRIPTION
This release includes the support for the `scratch` option. For s3 storage, allow the user to authorize with session token. It also includes several bugfixes. See the details below.

What's Changed:

* [GH-75](https://github.com/MemVerge/nf-float/issues/75) Too many `put xxx into map` log by @jealous in https://github.com/MemVerge/nf-float/pull/76
* [GH-77](https://github.com/MemVerge/nf-float/issues/77) Support s3 token authorization by @jealous in https://github.com/MemVerge/nf-float/pull/78
* [GH-77](https://github.com/MemVerge/nf-float/issues/77) Update the readme for s3 token by @jealous in https://github.com/MemVerge/nf-float/pull/79
* [GH-69](https://github.com/MemVerge/nf-float/issues/69) Support `float` in `ext` directive`. by @jealous in https://github.com/MemVerge/nf-float/pull/80
* [GH-63](https://github.com/MemVerge/nf-float/issues/63) Ignore the time limit by default. by @jealous in https://github.com/MemVerge/nf-float/pull/81
* [GH-82](https://github.com/MemVerge/nf-float/issues/82) Enable concurrent stage in by @jealous in https://github.com/MemVerge/nf-float/pull/84
* [GH-82](https://github.com/MemVerge/nf-float/issues/82) Default disk size to 6 GB. by @jealous in https://github.com/MemVerge/nf-float/pull/85
* FLOAT-4502 Avoid using plain credential. by @jealous in https://github.com/MemVerge/nf-float/pull/86
* [GH-87](https://github.com/MemVerge/nf-float/issues/87) Log parsing error for job ID by @jealous in https://github.com/MemVerge/nf-float/pull/88
* [GH-89](https://github.com/MemVerge/nf-float/issues/89) Use default disk size of MMC by @jealous in https://github.com/MemVerge/nf-float/pull/90
* [GH-91](https://github.com/MemVerge/nf-float/issues/91) default file stage in strategy to copy by @jealous in https://github.com/MemVerge/nf-float/pull/92

**Full Changelog**: https://github.com/MemVerge/nf-float/compare/0.4.3...0.4.4