### PR TITLE
Add nf-float 0.4.5

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2838,6 +2838,13 @@
         "url": "https://github.com/MemVerge/nf-float/releases/download/0.4.4/nf-float-0.4.4.zip",
         "requires": ">=23.04.0",
         "sha512sum": "29ab5cc167f2ac6f33e646e4caf9378bc2f3007d8c93aa4cdf549b8e05f02ec5999f0461fe866de9c3ca876cae101f5eb8a6d8c58a44ad61bd1ac7946001dc40"
+      },
+      {
+        "version": "0.4.5",
+        "date": "2024-09-18T16:17:27.62367-07:00",
+        "url": "https://github.com/MemVerge/nf-float/releases/download/0.4.5/nf-float-0.4.5.zip",
+        "requires": ">=23.04.0",
+        "sha512sum": "e127b79c94470ed141e37b7a18315897b80fd84a0a008480d3d825a316ce5e711d21b563de36e8ff9faa417c84e53c718637b3f2a01ec9e149cc31f36db16c4a"
       }
     ]
   },


### PR DESCRIPTION
Fixing a compatibility issue between MMC and AWS API. The endpoint for AWS region us-east-1 is different with other regions.  The algorithm used by MMC to provide the default endpoint does not work.

Add support in nf-float plugin to retrieve the endpoint configuration from `aws.client.endpoint` and supply this to MMC if available.

Do not change the default `scratch` option if user has local work dir.

Changes are available at:
https://github.com/MemVerge/nf-float/pull/94
https://github.com/MemVerge/nf-float/pull/95