### PR TITLE
Added nf-datatrail version 0.0.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3614,7 +3614,7 @@
     "releases": [
       {
         "version": "0.0.1",
-        "date": "2025-04-11T11:40:10.306817589+02:00",
+        "date": "2025-04-11T11:55:44.50351797+02:00",
         "url": "https://github.com/Lehmann-Fabian/nf-datatrail/releases/download/0.0.1/nf-datatrail-0.0.1.zip",
         "requires": ">=23.10.0",
         "sha512sum": "5d2aa1553c114bb4cbc2a45b8096b76e809059e1c2a550fe3288600a2459b3b5b3e088f182464628bfe2b44322f30a6b0a50dd5c6c8b5868d020748d7f14eba2"

--- a/plugins.json
+++ b/plugins.json
@@ -3614,10 +3614,10 @@
     "releases": [
       {
         "version": "0.0.1",
-        "date": "2025-04-11T11:25:56.214798832+02:00",
+        "date": "2025-04-11T11:40:10.306817589+02:00",
         "url": "https://github.com/Lehmann-Fabian/nf-datatrail/releases/download/0.0.1/nf-datatrail-0.0.1.zip",
-        "requires": ">=24.04.0",
-        "sha512sum": "e4f7811d95f70023c303013a0c0066298bfe9ed82e34ec0adcedb20b7167891d6d9728ebccff31415e578b186677b20c6274e392c05af49214e13d798b7b6f24"
+        "requires": ">=23.10.0",
+        "sha512sum": "5d2aa1553c114bb4cbc2a45b8096b76e809059e1c2a550fe3288600a2459b3b5b3e088f182464628bfe2b44322f30a6b0a50dd5c6c8b5868d020748d7f14eba2"
       }
     ]
   }

--- a/plugins.json
+++ b/plugins.json
@@ -3614,10 +3614,10 @@
     "releases": [
       {
         "version": "0.0.1",
-        "date": "2025-04-02T12:31:22.502790223+02:00",
+        "date": "2025-04-03T16:16:33.244124499+02:00",
         "url": "https://github.com/Lehmann-Fabian/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
         "requires": ">=24.04.0",
-        "sha512sum": "bd1a333fdacf839ad91aa22d4fcb015e99d99f9460bdfe2f37697ad4d18ca66fce9aefd86bb59dea14fc08a80adcf48b7305c68bc071bdbb7ef6e50e60469ab9"
+        "sha512sum": "28cfbd8243dcd0a937a1f5cb8e5bf8b8e9fc08fb3a6fd0d449306c0101c94b94ea8bcb37907404c87485af6bf27882f46bc0265dfa79cc2bc1cc8944abdee2a3"
       }
     ]
   }

--- a/plugins.json
+++ b/plugins.json
@@ -3610,14 +3610,14 @@
     ]
   },
   {
-    "id": "nf-dataflow",
+    "id": "nf-datatrail",
     "releases": [
       {
         "version": "0.0.1",
-        "date": "2025-04-03T16:16:33.244124499+02:00",
-        "url": "https://github.com/Lehmann-Fabian/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
+        "date": "2025-04-11T11:25:56.214798832+02:00",
+        "url": "https://github.com/Lehmann-Fabian/nf-datatrail/releases/download/0.0.1/nf-datatrail-0.0.1.zip",
         "requires": ">=24.04.0",
-        "sha512sum": "28cfbd8243dcd0a937a1f5cb8e5bf8b8e9fc08fb3a6fd0d449306c0101c94b94ea8bcb37907404c87485af6bf27882f46bc0265dfa79cc2bc1cc8944abdee2a3"
+        "sha512sum": "e4f7811d95f70023c303013a0c0066298bfe9ed82e34ec0adcedb20b7167891d6d9728ebccff31415e578b186677b20c6274e392c05af49214e13d798b7b6f24"
       }
     ]
   }

--- a/plugins.json
+++ b/plugins.json
@@ -3608,5 +3608,17 @@
         "requires": ">=24.10.0"
       }
     ]
+  },
+  {
+    "id": "nf-dataflow",
+    "releases": [
+      {
+        "version": "0.0.1",
+        "date": "2025-04-02T12:31:22.502790223+02:00",
+        "url": "https://github.com/nextflow-io/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
+        "requires": ">=24.0.0",
+        "sha512sum": "bd1a333fdacf839ad91aa22d4fcb015e99d99f9460bdfe2f37697ad4d18ca66fce9aefd86bb59dea14fc08a80adcf48b7305c68bc071bdbb7ef6e50e60469ab9"
+      }
+    ]
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -3615,6 +3615,7 @@
       {
         "version": "0.0.1",
         "date": "2025-04-02T12:31:22.502790223+02:00",
+        "url": "https://github.com/Lehmann-Fabian/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
         "url": "https://github.com/nextflow-io/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
         "requires": ">=24.0.0",
         "sha512sum": "bd1a333fdacf839ad91aa22d4fcb015e99d99f9460bdfe2f37697ad4d18ca66fce9aefd86bb59dea14fc08a80adcf48b7305c68bc071bdbb7ef6e50e60469ab9"

--- a/plugins.json
+++ b/plugins.json
@@ -3616,8 +3616,7 @@
         "version": "0.0.1",
         "date": "2025-04-02T12:31:22.502790223+02:00",
         "url": "https://github.com/Lehmann-Fabian/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
-        "url": "https://github.com/nextflow-io/nf-dataflow/releases/download/0.0.1/nf-dataflow-0.0.1.zip",
-        "requires": ">=24.0.0",
+        "requires": ">=24.04.0",
         "sha512sum": "bd1a333fdacf839ad91aa22d4fcb015e99d99f9460bdfe2f37697ad4d18ca66fce9aefd86bb59dea14fc08a80adcf48b7305c68bc071bdbb7ef6e50e60469ab9"
       }
     ]


### PR DESCRIPTION
This plugin visualizes and traces the physical DAG in Nextflow pipelines. It provides insights into data flow, process dependencies, and file sizes. I’d love to share this with the community!