### PR TITLE
Add nf-schema 2.4.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3483,6 +3483,13 @@
         "date": "2025-01-13T11:17:53.328630575+01:00",
         "sha512sum": "d2f787ca1086851f0fe7b97e2f77b53a186084d1e30e9b441ba3116908783c377d95ffc827dfcc8b15ab783d0d51a8e36638d0a2042963e355203713406f1b7c",
         "requires": ">=23.10.0"
+      },
+      {
+        "version": "2.4.0",
+        "date": "2025-04-03T15:11:57.654089844+02:00",
+        "url": "https://github.com/nextflow-io/nf-schema/releases/download/2.4.0/nf-schema-2.4.0.zip",
+        "requires": ">=24.10.0",
+        "sha512sum": "e2a88e1021786101af2de8e1725b5f4486abb49905ec870552e7a0ac568ba292dfcedbb9175c1bf512af097dabb7f64bb1efefbcdff9681f6f18167785b7805d"
       }
     ]
   },


### PR DESCRIPTION
# Version 2.4.0

## New features

1. Added a new configuration option: `validation.maxErrValSize` which sets the maximum length that a value in an error message can be. The default is set to 150 characters.
2. Added a new function: `validate()` that can be used to validate any data structure using a JSON schema.

## Bug fixes

1. Move the unpinned version check to an observer. This makes sure the warning is always shown and not only when importing a function.
2. Added a missing inherited method to the observer to fix issues with workflow output publishing
3. Fixed unexpected failures with samplesheet schemas using `anyOf`, `allOf` and `oneOf`
4. Fixed an error with help messages when the `type` keyword was missing
5. Fix compilation errors in Java 21

## Improvements

1. Slow uniqueness check (> 2hrs for 100k samples) made 400x faster by switching from `findAll` to a `subMap` for isolating the required unique fields.
2. `patternProperties` now has greater support, with no warnings about invalid parameters which actually match a pattern
3. Added better error handling and debug messages to the configuration parser.

## Changes

1. Refactored the whole codebase to make future development easier
2. Bumped the minimal Nextflow version to `24.10.0`