### PR TITLE
Add the plugin nf-fgbio from @fulcrumgenomics

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3777,5 +3777,17 @@
         "requires": ">=24.10.4"
       }
     ]
+  },
+  {
+    "id": "nf-fgbio",
+    "releases": [
+      {
+        "version": "1.0.0",
+        "date": "2025-05-17T09:00:00.130986Z",
+        "url": "https://github.com/fulcrumgenomics/nf-fgbio/releases/download/1.0.0/nf-fgbio-1.0.0.zip",
+        "requires": ">=22.10.2",
+        "sha512sum": "a5987c72f52831e0fb0b4cf5ba8d7a3376ce983111be55b393e6e49aa5c65fa000186ffbfe35fd48393eb47a55bd57b5f0a7fdb1e0b7403fcb86be1f99aa6f7c"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Hello Nextflow community and Seqera!

I've written a small plugin that exposes some useful functions and factory methods using dataclasses in [`fgbio`](https://github.com/fulcrumgenomics/nf-fgbio). 

In particular, two such methods have been initially implemented:

1. We often pass in [Read Structures](https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures) as a parameter or metadata on samples to pipelines, and the `readStructure` method will return a [`ReadStructure`](https://www.javadoc.io/doc/com.fulcrumgenomics/fgbio_2.13/latest/com/fulcrumgenomics/util/ReadStructure.html) object, which is really useful in itself, but it does parsing and yields better error messages when the read structure is invalid (see an [online validator](https://fulcrumgenomics.github.io/fgbio/validate-read-structure.html) for similar messages).
2. We (and many others) often have channels of _sample_ metadata, typically parsed from a sample sheet.   The `fromSampleSheet` can create a channel of [samples objects](https://www.javadoc.io/doc/com.fulcrumgenomics/fgbio_2.13/latest/com/fulcrumgenomics/illumina/Sample.html) from a sample sheet, giving named access to these attributes on samples.

We may choose to expose additional classes and methods from fgbio through this plugin.  We intend to use this not only for our clients, but also in nf-core pipelines we maintain (e.g. [in fastquorum](https://github.com/nf-core/fastquorum/blob/e6414c99ef5eef47a4ac3f124962e3dc5c21ab4b/assets/schema_input.json#L44-L49)).

The upstream repository is here:

https://github.com/fulcrumgenomics/nf-fgbio

This is my first time writing a plugin and seeking inclusion into the plugin registry; please let me know if I've missed a step or need to edit the submission!

Thank you for your time in reviewing this request!