### PR TITLE
nf-python v0.1.3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4060,6 +4060,13 @@
         "date": "2025-07-05T21:33:08+00:00",
         "sha512sum": "54af03c7179e23a66387dada49cfea588a8f3e25b8e66d662cee5134eafb4ddb217004791beaf87bb4c6aef64c01d3fda5452dd6ec47f1593e2c4f8bf841e866",
         "requires": ">=22.04.0"
+      },
+      {
+        "version": "0.1.3",
+        "date": "2025-07-28T15:30:22+03:00",
+        "url": "https://github.com/royjacobson/nf-python/releases/download/v0.1.3/nf-python-0.1.3.zip",
+        "requires": ">=23.04.0",
+        "sha512sum": "153133443c0f04059b744c8fd4ece1fddb9c3ee271d68043eef04ab6caeea0bcf4005ddc1eb055e3c8c4f57457b6383fd9ae3338c53a964af110be61dfecc291"
       }
     ]
   },


### PR DESCRIPTION
I made some two nice improvements to the python setup process:

* The plugin now comes with the python part built in - so there are no installation steps and there can't be version mismatches.
* It supports specifying python executable path or conda environment name - making it possible to run different parts under different environments and to reuse Nextflow's excellent support for conda envs.

All new functionality has CI tests, and I also run a quick test with the draft plugin repo - 

```
[user@fedora nf-plugins-repository]$ export NXF_PLUGINS_TEST_REPOSITORY=https://raw.githubusercontent.com/royjacobson/nf-plugins-repository/refs/heads/nf-python/plugins.json
[user@fedora test]$ nextflow run test.nf -plugins 'nf-python@0.1.3'
Nextflow 25.04.6 is available - Please consider updating your version to it

 N E X T F L O W   ~  version 25.04.2

WARN: =======================================================================
=                                WARNING                                    =
= You are running this script using a un-official plugin repository.        =
=                                                                           =
= https://raw.githubusercontent.com/royjacobson/nf-plugins-repository/refs/heads/nf-python/plugins.json
=                                                                           =
= This is only meant to be used for plugin testing purposes.                =
=============================================================================

Launching `test.nf` [confident_lavoisier] DSL2 - revision: c2073563b7

Creating env using conda: six [cache /home/user/test/work/conda/env-f41497d2762d3fecba6733256c4728e5]
[python] Package 'six' available!
```